### PR TITLE
2846 Added opacity of 1 to MuiTableSortLabel icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 
 -   Updated MUI `<Tooltip>` font size to .75rem ([#8](https://github.com/brightlayer-ui/react-themes/issues/8)).
--   Changed MUI `<TableSortLabel>` light theme hovered icon color to text secondary and non-hovered icon opacity to `0.36` ([#11](https://github.com/brightlayer-ui/react-themes/issues/11)).
+-   Updated `<TableSortLabel>` styles ([#11](https://github.com/brightlayer-ui/react-themes/issues/11)).
 
 ## v6.1.0 (November 8, 2021)
 

--- a/src/blueDarkTheme.ts
+++ b/src/blueDarkTheme.ts
@@ -764,7 +764,8 @@ export const blueDarkTheme: ThemeOptions = {
                 },
             },
             icon: {
-                opacity: 0.36,
+                opacity: 1,
+                color: Color(BLUIColors.gray[500]).alpha(0.24).string()
             },
         },
 

--- a/src/blueDarkTheme.ts
+++ b/src/blueDarkTheme.ts
@@ -765,7 +765,7 @@ export const blueDarkTheme: ThemeOptions = {
             },
             icon: {
                 opacity: 1,
-                color: Color(BLUIColors.gray[500]).alpha(0.24).string()
+                color: Color(BLUIColors.black[200]).alpha(0.24).string()
             },
         },
 

--- a/src/blueTheme.ts
+++ b/src/blueTheme.ts
@@ -702,7 +702,8 @@ export const blueTheme: ThemeOptions = {
                 },
             },
             icon: {
-                opacity: 0.36,
+                opacity: 1,
+                color: Color(BLUIColors.gray[500]).alpha(0.12).string(),
             },
         },
 

--- a/src/blueTheme.ts
+++ b/src/blueTheme.ts
@@ -659,7 +659,7 @@ export const blueTheme: ThemeOptions = {
                 },
             },
             icon: {
-                opacity: 0.12,
+                opacity: 1,
             },
         },
 

--- a/src/blueTheme.ts
+++ b/src/blueTheme.ts
@@ -653,13 +653,13 @@ export const blueTheme: ThemeOptions = {
                 '&:hover': {
                     color: ThemeColors.text.primary,
                     '& $icon': {
-                        color: BLUIColors.black[300],
+                        color: ThemeColors.text.secondary,
                         opacity: 1,
                     },
                 },
             },
             icon: {
-                opacity: 1,
+                opacity: 0.36,
             },
         },
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #11 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Changed opacity of icon to 1

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

https://user-images.githubusercontent.com/25982779/150321290-a59b5b76-52d2-47e9-9810-19d11ac1e1b0.mov


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start:showcase
