### PR TITLE
Feature/pxblue 2847 theme divider color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
--   Fix light theme to use black 500 for divider.
+-   Fix light theme to use black 500 for divider. ([#17](https://github.com/brightlayer-ui/react-themes/issues/17)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v6.1.1 (Unreleased)
 
+### Fixed
+
+-   Fix light theme to use black 500 for divider.
+
 ### Changed
 
 -   Updated MUI `<Tooltip>` font size to .75rem ([#8](https://github.com/brightlayer-ui/react-themes/issues/8)).

--- a/src/blueTheme.ts
+++ b/src/blueTheme.ts
@@ -23,7 +23,7 @@ const ThemeColors = {
     error: createSimplePalette(BLUIColors.red),
     success: createSimplePalette(BLUIColors.green),
     info: createSimplePalette(BLUIColors.lightBlue),
-    divider: Color(BLUIColors.black[200]).alpha(0.36).string(),
+    divider: Color(BLUIColors.red[500]).alpha(0.36).string(),
     warning: {
         light: BLUIColors.yellow[100],
         main: BLUIColors.yellow[500],

--- a/src/blueTheme.ts
+++ b/src/blueTheme.ts
@@ -23,7 +23,7 @@ const ThemeColors = {
     error: createSimplePalette(BLUIColors.red),
     success: createSimplePalette(BLUIColors.green),
     info: createSimplePalette(BLUIColors.lightBlue),
-    divider: Color(BLUIColors.red[500]).alpha(0.36).string(),
+    divider: Color(BLUIColors.black[500]).alpha(0.12).string(),
     warning: {
         light: BLUIColors.yellow[100],
         main: BLUIColors.yellow[500],
@@ -64,6 +64,7 @@ export const blueTheme: ThemeOptions = {
         error: ThemeColors.error,
         success: ThemeColors.success,
         info: ThemeColors.info,
+        divider: ThemeColors.divider,
         warning: ThemeColors.warning,
         background: ThemeColors.background,
         text: ThemeColors.text,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #17  .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update light theme to export divider and set divider to use black 500 
- divider: Color(BLUIColors.black[500]).alpha(0.12).string()
- 
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- 
