### PR TITLE
Feature/2775 input filled hover bg color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   Fix light theme to use black 500 for divider. ([#17](https://github.com/brightlayer-ui/react-themes/issues/17)).
+-   Fixed MUI `<Input>` `filled` variant's background color when focused on mobile devices ([#2](https://github.com/brightlayer-ui/react-themes/issues/2)).
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/react-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "6.1.1-beta.0",
+    "version": "6.1.1-beta.1",
     "description": "React themes for Brightlayer UI applications",
     "main": "index.js",
     "scripts": {

--- a/src/blueTheme.ts
+++ b/src/blueTheme.ts
@@ -13,8 +13,11 @@ import {
 } from "./shared";
 import * as BLUIColors from "@brightlayer-ui/colors";
 import Color from "color";
+import createBreakpoints from "@material-ui/core/styles/createBreakpoints";
 
-/* 
+const breakpoints = createBreakpoints({});
+
+/*
     Variable color definitions so we can reuse them in the theme overrides below
 */
 const ThemeColors = {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #2 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Mobile Viewport Focused color fix for Filled Inputs

Before:
![Filled Before](https://user-images.githubusercontent.com/6538289/150587263-294c5ce3-0ec2-40af-9097-11a3a44a60d9.gif)

After:
![Filled After](https://user-images.githubusercontent.com/6538289/150587274-5a725326-8bbf-4ab5-ac08-03ac651f95f2.gif)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Run the showcase and observe on a mobile device, simulate a phone in chrome dev tools.
